### PR TITLE
minor updates

### DIFF
--- a/newsletters/2023-02.md
+++ b/newsletters/2023-02.md
@@ -34,9 +34,11 @@ Read more about [applying for an OBF Event Fellowship](https://www.open-bio.org/
 
 ### BOSC News
  
-Our annual get-together, the Bioinformatics Open Source Conference (BOSC) 2023, will take place July 24-25 as a COSI of ISMB/ECCB 2023. It will once again be a hybrid event; in-person in Lyon (France), and online. We hope that the online component will offer the opportunity for many of you to participate that otherwise could not. 
+Our annual get-together, the [Bioinformatics Open Source Conference (BOSC) 2023](https://www.open-bio.org/events/bosc-2023/), will take place July 24-25 as a COSI of ISMB/ECCB 2023. It will once again be a hybrid event; in-person in Lyon (France), and online. We hope that the online component will offer the opportunity for many of you to participate that otherwise could not. 
 
-Note that **the abstract submission deadline is April 20** and you can request assistance for registration fees when submitting an abstract. 
+Note that **the regular abstract submission deadline is April 20** and you can request assistance for registration fees when submitting an abstract.
+
+**New this year**, BOSC is offering an "Early Poster Acceptance" option -- [submit your abstract](https://www.open-bio.org/events/bosc-2023/submit/) by March 31 to hear by April 6 whether it's accepted for (at least) a poster!
 
 For more detailed information, see the [BOSC 2023 webpage](https://www.open-bio.org/events/bosc-2023/).
 
@@ -59,9 +61,9 @@ The full meeting minutes are available in [this pull request](https://github.com
 ## Community updates
 
 ### Online webinar on patient-led research hosted by ISCBacademy
-Join us Tuesday, March 14, 15:00 UTC / 11am ET for a webinar about "Re-Thinking the Patient’s Role in a Learning Health System: Lessons from the Patient-Led Research Collaborative" by Hannah Wei, co-founder and technologist at the Patient-Led Research Collaborative, hosted by [ISCBacademy](https://www.iscb.org/iscbacademy). See [the webinar announcement](https://www.open-bio.org/2023/02/09/iscbacademy-webinar-on-patient-led-research/) for full details. 
+Join us Tuesday, March 14, at **11am EDT / 15:00 (not 16:00!) UTC**, for a webinar about "Re-Thinking the Patient’s Role in a Learning Health System: Lessons from the Patient-Led Research Collaborative" by Hannah Wei, co-founder and technologist at the Patient-Led Research Collaborative, hosted by [ISCBacademy](https://www.iscb.org/iscbacademy). See [the webinar announcement](https://www.open-bio.org/2023/02/09/iscbacademy-webinar-on-patient-led-research/) for full details. 
 
-If you're not familiar with [ISCBacademy](https://www.iscb.org/iscbacademy), it's a series of webinars offered by the (ISCB), which runs the annual ISMB conference, through the ISCB Communities of Special Interest (COSIs), which include BOSC/OBF. These webinars are now open to the public; you’ll just need to create an [ISCB Nucleus](https://iscb.junolive.co/) account to register for the webinar.
+If you're not familiar with [ISCBacademy](https://www.iscb.org/iscbacademy), it's a series of webinars offered by the [ISCB](https://www.iscb.org/), which runs the annual ISMB conference, through the ISCB Communities of Special Interest (COSIs), which include BOSC/OBF. These webinars are now open to the public; you’ll just need to create an [ISCB Nucleus](https://iscb.junolive.co/) account to [register for the webinar](https://iscb.junolive.co/Nucleus/live/mainstage/iscbacademycosi79).
 
 ### Google Summer of Code
 


### PR DESCRIPTION
reformatted time of webinar to emphasize timezone weirdness (March 12 we start 2 weeks of "Universal Bonkers Time": US/Canada "spring forward" to Daylight Saving Time, while UK/Europe don't switch to Summer Time until March 26. That means tha the webinar on March 14 @ 11am EDT will start at 15:00 UK time, not 16:00.)

added some hyperlinks

added note about early poster acceptance